### PR TITLE
Fix jitter when following a player while spectating

### DIFF
--- a/lua/CompMod/Config.lua
+++ b/lua/CompMod/Config.lua
@@ -63,6 +63,7 @@ local modules = {
 	"Global/ResponsiveGUI",
 	"Global/Physics",
 	"Global/SupplyDisplay",
+	"Global/SpectatorEdgePanning",
 
 	--[[
 	  ==========================

--- a/lua/CompMod/Global/SpectatorEdgePanning/Post/NetworkMessages_Server.lua
+++ b/lua/CompMod/Global/SpectatorEdgePanning/Post/NetworkMessages_Server.lua
@@ -1,0 +1,19 @@
+local function onSpectatePlayer(client, message)
+
+    local spectatorPlayer = client:GetControllingPlayer()
+    if spectatorPlayer then
+
+        -- This only works for players on the spectator team.
+        if spectatorPlayer:GetTeamNumber() == kSpectatorIndex then
+            client:GetControllingPlayer():SelectEntity(message.entityId)
+            if message.entityId == Entity.invalidId then
+                spectatorPlayer:SetOverheadMoveEnabled(true)
+            else
+                spectatorPlayer:SetOverheadMoveEnabled(false)
+            end
+        end
+
+    end
+
+end
+Server.HookNetworkMessage("SpectatePlayer", onSpectatePlayer)


### PR DESCRIPTION
Enable/Disable OverheadMove for spectators when following a player in overhead mode to prevent edge panning jitters